### PR TITLE
App: Enhance Translation

### DIFF
--- a/mobile/src/main/res/values-zh-rCN/strings.xml
+++ b/mobile/src/main/res/values-zh-rCN/strings.xml
@@ -25,7 +25,7 @@
 
 	<string name="action_remove">移除</string>
 	<string name="toast_item_removed">%s 已被移除。</string>
-	<string name="toast_item_removed_action">撤回</string>
+	<string name="toast_item_removed_action">撤销</string>
 	<string name="toast_all_read">%d 个包裹已标为已读。</string>
 
 	<!-- Add -->

--- a/mobile/src/main/res/values-zh-rTW/strings.xml
+++ b/mobile/src/main/res/values-zh-rTW/strings.xml
@@ -25,7 +25,7 @@
 
 	<string name="action_remove">移除</string>
 	<string name="toast_item_removed">%s 已被移除。</string>
-	<string name="toast_item_removed_action">撤回</string>
+	<string name="toast_item_removed_action">撤銷</string>
 	<string name="toast_all_read">%d 個包裹已標為已讀。</string>
 
 	<!-- Add -->


### PR DESCRIPTION
This PR changes toast button text when item removed.

- 「撤回」to「撤销」

I suggest this change as most applications use 「撤销」 instead of 「撤回」.
Usually 「撤回」 means recall some data from a server, while 「撤销」 means undo, and here the application is not recalling from a server.