### PR TITLE
App: Fix Search Result Mistake

### DIFF
--- a/mobile/src/main/java/info/papdt/express/helper/ui/CompanyChooserActivity.java
+++ b/mobile/src/main/java/info/papdt/express/helper/ui/CompanyChooserActivity.java
@@ -108,7 +108,7 @@ public class CompanyChooserActivity extends AbsActivity {
 			@Override
 			public void onItemClick(int position, SimpleRecyclerViewAdapter.ClickableViewHolder holder) {
 				Intent intent = new Intent();
-				intent.putExtra(RESULT_EXTRA_COMPANY_CODE, data.get(position).code);
+				intent.putExtra(RESULT_EXTRA_COMPANY_CODE, mAdapter.getItem(position).code);
 				setResult(RESULT_OK, intent);
 				finish();
 			}


### PR DESCRIPTION
Currently, when user filters company in the list, the application will choose the position of the entire list instead of the filtered list, which causes confusion. This PR fixes the bug.

Steps:
1. Tap "Choose company manually"
2. Type sth. in the search bar
3. Click on the first item, i.e. "shunfeng"
4. The company chosen will be "shentong" as it is the first in the entire list

And this PR fixes it.