### PR TITLE
Fix #8

### DIFF
--- a/mobile/src/main/java/info/papdt/express/helper/ui/fragment/add/StepInput.java
+++ b/mobile/src/main/java/info/papdt/express/helper/ui/fragment/add/StepInput.java
@@ -54,6 +54,7 @@ public class StepInput extends AbsStepFragment {
 		mButtonBar.setOnRightButtonClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View view) {
+				mEditText.setText(mEditText.getText().toString().trim());
 				if (!checkNumberInput()) {
 					Toast.makeText(getContext(), R.string.toast_number_wrong, Toast.LENGTH_SHORT).show();
 					return;


### PR DESCRIPTION
This PR fixes the second suggestion of issue #8 .

By simply adding a `trim()`, this PR enables the app to automatically remove the pre and post space of express number inputed.